### PR TITLE
Allows for upgrade to rails 7

### DIFF
--- a/activejob-scheduler.gemspec
+++ b/activejob-scheduler.gemspec
@@ -31,9 +31,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'sqlite3', '~> 1.4'
   spec.add_development_dependency 'yard', '>= 0.9.20'
 
-  spec.add_dependency 'actionmailer', '> 5', '< 7'
-  spec.add_dependency 'activejob', '> 5', '< 7'
-  spec.add_dependency 'activesupport', '> 5', '< 7'
+  spec.add_dependency 'actionmailer', '> 5', '<= 7'
+  spec.add_dependency 'activejob', '> 5', '<= 7'
+  spec.add_dependency 'activesupport', '> 5', '<= 7'
   spec.add_dependency 'fugit', '~> 1.3'
   spec.add_dependency 'travis-release', '~> 0'
 end


### PR DESCRIPTION
# Summary
Needed to allow for gems in the 7.0 range so we could update management and blacklight to Rails 7.0.

# Related Ticket
[#2348](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/gh/yalelibrary/yul-dc/2348)